### PR TITLE
Update test instructions, database configuration, and user service

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Este proyecto usa `pytest` para ejecutar pruebas. Todas las pruebas están en la
 ### **Ejecutar Todas las Pruebas**
 
 ```bash
-pytest
+python - pytest
 ```
 
 ### **Ejecutar una Prueba Individual**
@@ -121,13 +121,13 @@ pytest
 Si solo deseas ejecutar un archivo específico de pruebas:
 
 ```bash
-pytest tests/test_nombre_archivo.py
+python -m pytest tests/test_nombre_archivo.py
 ```
 
 Ejemplo:
 
 ```bash
-pytest tests/test_client.py
+python -m pytest tests/test_client.py
 ```
 
 ---

--- a/db.py
+++ b/db.py
@@ -3,8 +3,9 @@ import sqlite3
 import os
 from contextlib import contextmanager
 
-# Default database path (in-memory unless overridden)
-DB_PATH = os.getenv("DB_PATH", ":memory:")
+# Default to a persistent file-based database.
+# When testing/developing, you can override this via an environment variable.
+DB_PATH = os.environ.get("DB_PATH", "data.db")
 
 # Path to the SQL schema file
 SQL_FILE_PATH = "./harina.sql"
@@ -20,7 +21,7 @@ def db_connection():
             cursor.execute("SQL_QUERY")
             result = cursor.fetchall()
     """
-    conn = sqlite3.connect(DB_PATH)
+    conn = sqlite3.connect(DB_PATH, uri=DB_PATH.startswith("file:"))
     conn.row_factory = sqlite3.Row  # Allows accessing columns by name
     try:
         yield conn  # Return the connection for use

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,15 @@
 # tests/conftest.py
 import pytest
-from db import db_connection, init_db
+import db
+
+
+@pytest.fixture(scope="session", autouse=True)
+def configure_test_db(tmp_path_factory):
+    # Create a temporary directory and database file.
+    temp_db = tmp_path_factory.mktemp("data") / "test.db"
+    db.DB_PATH = str(
+        temp_db
+    )  # Override the DB_PATH used by db_connection() and init_db()
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -9,9 +18,7 @@ def fresh_db():
     This fixture runs before each test function.
     It creates a new in-memory database schema so each test is isolated.
     """
-    with db_connection() as conn:
-        init_db()
+    with db.db_connection() as conn:
+        db.init_db()
         # Test runs here
         yield conn
-        # Teardown (in memory DB goes away when connection closes, so nothing else needed)
-        conn.close()


### PR DESCRIPTION
- Update README.md to use 'python -m pytest' for running tests.
- Modify db.py to default to a persistent file-based database (data.db) with override via environment variable.
- Refactor services/user_service.py to use db_connection for CRUD operations on the USUARIO table.
- Adjust tests/conftest.py to configure a temporary file-based database for testing using pytest’s tmp_path.

This change allows developers to use a temporary database during testing while production uses persistent storage.